### PR TITLE
Changing parameter store to secrets manager

### DIFF
--- a/infrastructure/lib/lambda/utils/getParameter.ts
+++ b/infrastructure/lib/lambda/utils/getParameter.ts
@@ -2,23 +2,22 @@
 // SPDX-License-Identifier: MIT-0
 
 import AWS = require('aws-sdk');
-const ssm = new AWS.SSM({
-    apiVersion: '2014-11-06'
+const ssm = new AWS.SecretsManager({
+    region: process.env.AWS_REGION
 });
 
 export const getParamFromSSM = async (path: string) => {
     try {
         const query = {
-            Name: path,
-            WithDecryption: true,
+            SecretId: path
         };
-        const getParameterResult = await ssm.getParameter(query).promise();
+        const getParameterResult = await ssm.getSecretValue(query).promise();
 
         if (getParameterResult === undefined) {
             console.error("Unable to getParameter with this query: " + query);
             return "No Data"
         } else {
-            return getParameterResult.Parameter?.Value;
+            return getParameterResult.SecretString;
         }
     } catch (error) {
         console.error(`*** Error: ${error}`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Token value moved from Parameter store to AWS Secrets Manager
- Removed Domain for Cognito
- Reduce refresh token duration to 2 hours.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
