### PR TITLE
Fix type error in update method parameters

### DIFF
--- a/infrastructure/lib/lambda/updateOrder.ts
+++ b/infrastructure/lib/lambda/updateOrder.ts
@@ -70,7 +70,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
                 Key: key,
                 UpdateExpression: `set ${firstProperty} = :${firstProperty}`,
                 ExpressionAttributeValues: {},
-                ReturnValues: 'UPDATED_NEW'
+                ReturnValues: 'UPDATED_NEW' as const
             }
             params.ExpressionAttributeValues[`:${firstProperty}`] = editedItem[`${firstProperty}`];
 


### PR DESCRIPTION
Resolved a type error in the parameters of the update method by explicitly defining 'UPDATED_NEW' as a string literal type for the 'ReturnValues' property.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
